### PR TITLE
Add API key header to get_api_key function

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException, Depends, status, Header
 from OpenSSL import crypto
 from pyasn1.codec.der import decoder
 from pyasn1.type import univ, char, namedtype, namedval, tag, constraint, useful
+from fastapi.security import APIKeyHeader
 
 
 class DNSName(univ.Choice):
@@ -38,8 +39,10 @@ class GeneralNames(univ.SequenceOf):
 
 app = FastAPI()
 
+api_key_header = APIKeyHeader(name="X-API-Key")
 
-def get_api_key(api_key: str = Header(None)):
+
+def get_api_key(api_key: str = Depends(api_key_header)):
     if api_key is None or api_key != environ.get("API_KEY"):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
     return api_key


### PR DESCRIPTION
This pull request adds an API key header using the `fastapi.security`'s `APIKeyHeader` module to the `get_api_key` function in order to authenticate requests.