### PR TITLE
Update min_machines_running value to 1

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,7 +13,7 @@ primary_region = 'mia'
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [env]


### PR DESCRIPTION
This pull request updates the `min_machines_running` value in the configuration file to 1. Previously, the value was set to 0, but this change ensures that at least one machine is always running. This is necessary for the proper functioning of the application.