### PR TITLE
Refactor get_ssl_domains to return domains as a dictionary with hostname as key

### DIFF
--- a/gsan/main.py
+++ b/gsan/main.py
@@ -210,4 +210,4 @@ def get_ssl_domains(
     """
     seen_domains = set()
     domains = get_domains_recursive(hostname, port, seen_domains, timeout, recursive)
-    return {"domains": domains}
+    return {hostname: domains}

--- a/gsan/test_main.py
+++ b/gsan/test_main.py
@@ -4,7 +4,6 @@ from fastapi.testclient import TestClient
 from gsan import app
 
 client = TestClient(app)
-api_key_header = {"X-API-KEY": environ.get("API_KEY")}
 
 
 def test_read_main():
@@ -13,6 +12,6 @@ def test_read_main():
 
 
 def test_get_ssl_domains():
-    response = client.get("/ssl_domains/self-signed.badssl.com", headers=api_key_header)
+    response = client.get("/ssl_domains/self-signed.badssl.com")
     assert response.json() == {"domains": ["badssl.com"]}
     assert response.status_code == 200

--- a/gsan/test_main.py
+++ b/gsan/test_main.py
@@ -12,6 +12,7 @@ def test_read_main():
 
 
 def test_get_ssl_domains():
-    response = client.get("/ssl_domains/self-signed.badssl.com")
-    assert response.json() == {"domains": ["badssl.com"]}
+    domain = "self-signed.badssl.com"
+    response = client.get(f"/ssl_domains/{domain}")
+    assert response.json() == {domain: ["badssl.com"]}
     assert response.status_code == 200


### PR DESCRIPTION
This pull request refactors the get_ssl_domains function to return the domains as a dictionary with the hostname as the key. It also removes an unnecessary API key header in the test_get_ssl_domains function and refactors it to use a dynamic domain variable.